### PR TITLE
Update gtfs.js

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -516,7 +516,7 @@ module.exports = {
       async.forEach(shape_ids, function(shape_id, cb) {
         Shape.find({
           agency_key: agency_key,
-          shape_id: parseInt(shape_id, 10),
+          shape_id: shape_id,
         }, function(err, shape_pts) {
           if(shape_pts.length) {
             shapes.push(shape_pts);


### PR DESCRIPTION
E.g. in Chattanooga, our shape IDs aren't integers: https://github.com/gocarta/gtfs/blob/master/trips.txt

This value should be treated as a string throughout. In the mongoose models, shape_id is treated as a string.
